### PR TITLE
Better alignment of topics in openrtb with IAB SDA spec and existing practice

### DIFF
--- a/proposals/topics-rtb/README.md
+++ b/proposals/topics-rtb/README.md
@@ -125,3 +125,29 @@ The OpenRTB representation can look like the following:
   }
 }
 ```
+
+- Perhaps the specification should follow the [Segment Taxonomies](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/segtax.md). proposal precisely, as some parties have already begun transmitting this way.  Please note the origin trial period taxonomy has already been assigned segtax 600 and additional segtax id's (it is an enum, not a string) are simple to reserve in blocks from the IAB. In this case, user.data.id doesn't typically have meaning, user.data.name is the entity reported to have chosen audience membership in the segment
+
+
+```
+{
+  ...,
+  "user": {
+    "data": [
+      {
+        "name": "chrome.com", // or perhaps 'publisher.com' or 'thirdpartycaller.com' is more appropriate
+        "ext": {
+          "segtax": 600
+          "segclass": "v1" //this is not considered in the sda spec, but seems the appropriate place for it
+        }
+        "segment": [
+          {
+            "id": "111"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+


### PR DESCRIPTION
The alignment with IAB proposed in the doc had a few flaws, segtax is an enum, user.data.id is not used, user.data.name is. Many parties will be transmitting per these changes imminently, except that classifier version will be omitted. user.data.ext.segclass seems like a fine place for classifier version, but the string 'class' doesn't need to be part of both the key and the value, eg 'segclass': 'class_v1'.

Note this is a resubmit for cla reasons of https://github.com/google/ads-privacy/pull/61