### PR TITLE
PAAPI RTB: Adds addtl detail around seller forwarding buyer signals

### DIFF
--- a/proposals/fledge-rtb/README.md
+++ b/proposals/fledge-rtb/README.md
@@ -124,8 +124,8 @@ FLEDGE allows to pass buyer-specific contextual signals into the on-device biddi
 
 #### Example of how a Seller would interpret and forward Buyer `igbid`s
 
-- Each igbuyer.origin that the buyer provides should be included as an interestGroupBuyer(s) entry in the seller's auctionConfig.
-- For each combination of origin and buyerdata, there should be a corresponding perBuyerSignals key:value pair in the seller's auctionConfig. In this pairing, the origin serves as the key, and the buyerdata acts as the associated value.
+- Each igbuyer.igdomain that the buyer provides should be included as an interestGroupBuyer(s) entry in the seller's auctionConfig.
+- For each combination of igdomain and buyerdata, there should be a corresponding perBuyerSignals key:value pair in the seller's auctionConfig. In this pairing, the igdomain serves as the key, and the buyerdata acts as the associated value.
 
 Bid Response from Buyer to Exchange/SSP
 ```


### PR DESCRIPTION
Language used within working groups has primarily involved parties suggesting that the igbid data supplied by the buyer be directly transferred or sent unchanged between the seller and the publisher/supply source. However, this language omits crucial details regarding the Seller's server-side obligations and the correct restructuring of the provided igbid data. This restructuring is necessary to ensure its accurate presentation for the buyer's on-device auction.

This pull request introduces more precise language and offers examples outlining the seller's responsibilities when relaying igbid, interestGroupBuyer, and perBuyerSignal data to the on-device auction mechanism.